### PR TITLE
handle the case where @pbx_objects[object_id] is nil, bump to 1.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Cocoa Pods
 
 pbxproj_structure_check can be integrated into your project using [CocoaPods](http://cocoapods.org). Add following entry to your Podfile:
 
-	pod 'pbxproj_structure_check', '~> 1.0.1'
+	pod 'pbxproj_structure_check', '~> 1.0.2'
 
 Then add a 'Run Script' build phase to your app target (see **Add to Xcode as Build Phase** for details). Type following as build phase script:
 

--- a/pbxproj_structure_check.podspec
+++ b/pbxproj_structure_check.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "pbxproj_structure_check"
-  s.version      = "1.0.1"
+  s.version      = "1.0.2"
   s.summary      = "Simple ruby script to check if a Xcode *.pbxproj file objects structure matches a project physical directory structure"
   s.description = <<-DESC
     Simple ruby script to check if a Xcode *.pbxproj file objects structure matches a project physical directory structure. You need to enable pbxproj_structure_check.rb script manually as described on https://github.com/kam800/pbxproj_structure_check.git.
@@ -9,6 +9,6 @@ Pod::Spec.new do |s|
   s.screenshots  = "https://github.com/kam800/pbxproj_structure_check/raw/master/readme_imgs/readme_img8.png", "https://github.com/kam800/pbxproj_structure_check/raw/master/readme_imgs/readme_img7.png"
   s.license      = 'MIT'
   s.author       = { "Kamil Borzym" => "kamil.borzym@gmail.com" }
-  s.source       = { :git => "https://github.com/kam800/pbxproj_structure_check.git", :tag => "1.0.1" }
+  s.source       = { :git => "https://github.com/kam800/pbxproj_structure_check.git", :tag => "1.0.2" }
   s.preserve_path = "pbxproj_structure_check.rb"
 end

--- a/pbxproj_structure_check.rb
+++ b/pbxproj_structure_check.rb
@@ -1,6 +1,6 @@
 #
 #  pbxproj_structure_check.rb
-#  v.1.0.1
+#  v.1.0.2
 #
 #  Copyright (c) 2014 Kamil Borzym
 #  Released under the MIT License
@@ -13,51 +13,62 @@ class PbxStructure
 
   attr_accessor :ignored_ids
 
-  def initialize(pbx_tree)
+  def initialize(pbx_tree, pbx_path)
     @pbx_tree = pbx_tree
+    @pbx_path = pbx_path
     @pbx_objects = pbx_tree["objects"]
+    @check_failed = false
   end
-  
+  def status
+    return !@check_failed
+  end
   def check_object(object_id, object_location)
     if (not @ignored_ids.nil?) and (@ignored_ids.include?(object_id))
       return
     end
     object = @pbx_objects[object_id]
-    
+    if object.nil?
+      puts "object '#{object_id}' in '#{object_location}' is nil. delete and re-add it in Xcode."
+      puts "-- the following lines may provide a clue as to that object's name ---"
+      system("grep #{object_id} '#{@pbx_path}'")
+      puts "--- end of clues ---"
+      @check_failed = true
+      return
+    end
+
     if object_location.empty?
       object_description = "Object '#{object_id}' named '#{object["name"]}' at '/'"
-    else 
+    else
       object_description = "Object '#{object_id}' named '#{object["name"]}' at '#{object_location}'"
     end
-    
+
     if not object["sourceTree"].eql?("<group>")
-      abort "#{object_description} is not relative to <group> but to #{object["sourceTree"]}"
+      abort "error: #{object_description} is not relative to <group> but to #{object["sourceTree"]}"
     end
     if object["path"].nil?
-      abort "#{object_description} has no physical path"
+      abort "error: #{object_description} has no physical path"
     end
     if (not object["name"].nil?) and (not object["name"].eql?(object["path"]))
-      abort "#{object_description} has name '#{object["name"]}' different from its real path '#{object["path"]}'"
+      abort "error: #{object_description} has name '#{object["name"]}' different from its real path '#{object["path"]}'"
     end
-  
+
     children_location = "#{object_location}/#{object["path"]}"
     if not object["children"].nil?
       object["children"].each do |child_id|
         check_object(child_id, children_location)
-      end 
+      end
     end
   end
-  
+
   def check
     root_object = @pbx_objects[@pbx_tree["rootObject"]]
     main_group = @pbx_objects[root_object["mainGroup"]]
-  
+
     main_group["children"].each do |child_id|
       check_object(child_id, "")
    end
   end
 end
-
 
 if __FILE__ == $0
   def usage
@@ -68,16 +79,20 @@ if __FILE__ == $0
   if pbx_path.nil?
     usage
   end
-  pbx_data = `plutil -convert json -o - #{ARGV[0]}`
+  pbx_data = `plutil -convert json -o - #{pbx_path}`
   if $? != 0
     abort "Could not read project file!"
   end
-  
+
   pbx_tree = JSON.parse(pbx_data)
 
-  pbx_structure = PbxStructure.new(pbx_tree)
+  pbx_structure = PbxStructure.new(pbx_tree, pbx_path)
   if not ARGV[1].nil?
     pbx_structure.ignored_ids = ARGV[1].split(":")
   end
   pbx_structure.check
+  
+  if !pbx_structure.status
+    abort "check failed (see above)"
+  end
 end


### PR DESCRIPTION
## What it Does

Sometimes, a merge breaks the project file by removing a file from the PBXFileReference section, but leaving it in other places. When that happens, `@pbx_objects[object_id]` is `nil`, and you get 

```shell
Traceback (most recent call last):
	13: from Scripts/pbxproj_structure_check.rb:93:in `<main>'
	12: from Scripts/pbxproj_structure_check.rb:67:in `check'
	11: from Scripts/pbxproj_structure_check.rb:67:in `each'
	10: from Scripts/pbxproj_structure_check.rb:68:in `block in check'
	 9: from Scripts/pbxproj_structure_check.rb:57:in `check_object'
	 8: from Scripts/pbxproj_structure_check.rb:57:in `each'
	 7: from Scripts/pbxproj_structure_check.rb:58:in `block in check_object'
	 6: from Scripts/pbxproj_structure_check.rb:57:in `check_object'
	 5: from Scripts/pbxproj_structure_check.rb:57:in `each'
	 4: from Scripts/pbxproj_structure_check.rb:58:in `block in check_object'
	 3: from Scripts/pbxproj_structure_check.rb:57:in `check_object'
	 2: from Scripts/pbxproj_structure_check.rb:57:in `each'
	 1: from Scripts/pbxproj_structure_check.rb:58:in `block in check_object'
Scripts/pbxproj_structure_check.rb:42:in `check_object': undefined method `[]' for nil:NilClass (NoMethodError)
```
now you get something like 
```
object '3856254B1CF4CF0200AA5750' in '/YourProject/App/Flow' is nil. delete and re-add it in Xcode.
-- the following lines may provide a clue as to that object's name ---
		3856254C1CF4CF0200AA5750 /* MainFlowCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3856254B1CF4CF0200AA5750 /* MainFlowCoordinator.swift */; };
				3856254B1CF4CF0200AA5750 /* MainFlowCoordinator.swift */,
--- end of clues ---
```

## How to Test

remove a line from the PBXFileReference section of `project.pbxproj`, e.g.
```
		3856254B1CF4CF0200AA5750 /* MainFlowCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MainFlowCoordinator.swift; sourceTree = "<group>"; };
```
run `process.sh`
